### PR TITLE
hotfix/algorithm minor bugs

### DIFF
--- a/temple/src/main/java/student/AStar.java
+++ b/temple/src/main/java/student/AStar.java
@@ -22,28 +22,23 @@ public class AStar extends EscapeAlgorithm {
      */
     @Override
     public List<Node> bestPath(Node start, Node exit) {
-        System.out.println("Time remaining: " + timeRemaining);
         TreeSet<Node> nearestNodesWithGold = new TreeSet<>(Comparator.comparingInt(o -> estimate(o, start)));
-        TreeSet<Node> nodesWithGold = new TreeSet<>(Comparator.comparingInt(o -> o.getTile().getGold()));
+
         graph.forEach(n -> {
-            if (n.getTile().getGold() > 0) {
-                nodesWithGold.add(n);
+            if (n.getTile().getGold() > 0 && !n.equals(start)) {
+                nearestNodesWithGold.add(n);
             }
         });
 
-        // Get the top 10 nodes with the most gold and add them to the nearestNodesWithGold set.
-        for (int i = 0; i < 15; i++) {
-            Node node = nodesWithGold.pollLast();
-            if (node != null) {
-                nearestNodesWithGold.add(node);
-            }
-        }
-
         List<Node> path = new ArrayList<>();
-
         path.add(start);
 
+        if (nearestNodesWithGold.isEmpty()) {
+            path.addAll(shortestPath(start, exit));
+        }
+
         for (Node node : nearestNodesWithGold) {
+
             Node lastNode = path.get(path.size() - 1);
 
             if (node.equals(exit)) {
@@ -53,16 +48,12 @@ public class AStar extends EscapeAlgorithm {
 
             List<Node> pathToNextNode = shortestPath(lastNode, node);
 
-            if (pathToNextNode.size() == 1 || pathToNextNode.size() == 0) {
-                continue;
-            }
             Node lastNodeInNextMove = pathToNextNode.get(pathToNextNode.size() - 1);
 
             List<Node> pathToExit = shortestPath(lastNodeInNextMove, exit);
 
             List<Node> escapePath = shortestPath(lastNode, exit);
 
-            // if the time remaining is greater than the current path, plus the path to the next node, plus the path to the exit from that node, we are safe to add to the current path.
             if (timeRemaining > pathLength(path) + pathLength(pathToNextNode) + pathLength(pathToExit)) {
                 path.addAll(pathToNextNode);
             } else {
@@ -70,11 +61,16 @@ public class AStar extends EscapeAlgorithm {
                 break;
             }
         }
+        Node lastNode = path.get(path.size() - 1);
+        if (!lastNode.equals(exit)) {
+            path.addAll(shortestPath(lastNode, exit));
+        }
+
         if (pathLength(path) > timeRemaining) {
             path = shortestPath(start, exit);
         }
 
-        path.remove(0);
+        path.remove(start);
         return path;
     }
 

--- a/temple/src/main/java/student/AStar.java
+++ b/temple/src/main/java/student/AStar.java
@@ -63,16 +63,14 @@ public class AStar extends EscapeAlgorithm {
             List<Node> escapePath = shortestPath(lastNode, exit);
 
             // if the time remaining is greater than the current path, plus the path to the next node, plus the path to the exit from that node, we are safe to add to the current path.
-            if (timeRemaining > pathLength(path) + pathLength(pathToNextNode) + pathLength(pathToExit) + pathLength(escapePath)) {
+            if (timeRemaining > pathLength(path) + pathLength(pathToNextNode) + pathLength(pathToExit)) {
                 path.addAll(pathToNextNode);
             } else {
                 path.addAll(escapePath);
-                System.out.println("Escaping!, path length: " + pathLength(path));
                 break;
             }
         }
         if (pathLength(path) > timeRemaining) {
-            System.out.println("Escaping!, path length: " + pathLength(path));
             path = shortestPath(start, exit);
         }
 
@@ -109,8 +107,8 @@ public class AStar extends EscapeAlgorithm {
         int currentRow = node.getTile().getRow();
         int exitColumn = other.getTile().getColumn();
         int exitRow = other.getTile().getRow();
-        int manhattanDistance = Math.abs(currentColumn - exitColumn) + Math.abs(currentRow - exitRow);
-        return manhattanDistance + Cavern.MAX_GOLD_VALUE - node.getTile().getGold();
+
+        return Math.abs(currentColumn - exitColumn) + Math.abs(currentRow - exitRow);
     }
 
     /**

--- a/temple/src/main/java/student/Explorer.java
+++ b/temple/src/main/java/student/Explorer.java
@@ -105,8 +105,10 @@ public class Explorer {
         List<Node> escapeRoute;
 
         if (EscapeAlgorithm.totalGoldOnPath(dijkstraRoute) > EscapeAlgorithm.totalGoldOnPath(aStarRoute)) {
+            System.out.println("Dijkstra route is better");
             escapeRoute = dijkstraRoute;
         } else {
+            System.out.println("A* route is better");
             escapeRoute = aStarRoute;
         }
 

--- a/temple/src/main/java/student/Explorer.java
+++ b/temple/src/main/java/student/Explorer.java
@@ -105,10 +105,8 @@ public class Explorer {
         List<Node> escapeRoute;
 
         if (EscapeAlgorithm.totalGoldOnPath(dijkstraRoute) > EscapeAlgorithm.totalGoldOnPath(aStarRoute)) {
-            System.out.println("Dijkstra route is better");
             escapeRoute = dijkstraRoute;
         } else {
-            System.out.println("A* route is better");
             escapeRoute = aStarRoute;
         }
 


### PR DESCRIPTION
This MR fixes a couple of bugs in the A star alogirthm that were hard to detect until running the game many times (multiple runs of 10k). I previously had allowed the start node to be included in a list of nodes with gold meaning it was possible to try to build a path that moved to the start node, which is obviously bad. I'd also not correctly handled the situation where there was no gold, with some edge cases passing when they perhaps shouldn't have. Finally I was removing the first node from the path in all cases on the assumption it was the start node, however it was a valid scenario for the start node to not be on the path, now we only remove it if it exists in the path.

After multiple runs with the hotfix in place I've not been able to spot any failed runs and it seems that that it is frequently the Dijkstra algorithm that returns the most gold, however there is a not insignificant percentage of the time where the A star is more efficient.